### PR TITLE
docs: warn operators about token cost, prompt inspection, and Claude Code setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,13 @@ Stream the response and watch for `result` / error events; treat the eventual PR
 
 ### Operational notes
 
+**Verify Claude Code on the host.** kodezart invokes the Claude Code CLI as its agent runtime. Run `claude --version` on the deployment host and confirm the CLI is authenticated *before* kicking off any workflows — otherwise the first agent invocation fails with a confusing error rather than a clear setup message.
+
+**Inspect the prompt templates before deploying.** kodezart ships prompt templates in `src/kodezart/prompts/`. Every workflow run sends those templates (with your ticket interpolated) to Claude. Read them at least once so you know what the agent is being instructed to do on your repositories — particularly the drafter / reviewer prompts and the Ralph executor.
+
 **GitHub token for PR monitoring.** Set `KODEZART_GITHUB_TOKEN` to a PAT — classic with `repo` scope, or fine-grained with **Contents: read/write** + **Pull requests: read/write** + **Metadata: read** — if you want kodezart to clone private repositories and monitor the PRs it opens (the post-merge fix loop polls PR check runs to detect CI failures and react). Without a token, public-repo workflows still run, but private clones and CI monitoring are skipped.
+
+**Token budget — this is a heavy pipeline.** Every workflow run spins up multiple Claude sessions: ticket drafter, reviewer, Ralph executor (up to `KODEZART_MAX_ITERATIONS` times), and the post-merge fix loop. The throughput is high but the token cost is significant; running kodezart continuously for a few hours **will burn through any plan's usage limits**. To dial intensity down for sustained runs, lower `KODEZART_MAX_ITERATIONS` and `KODEZART_MAX_REVIEWS`, or trim the sub-agent preambles in `src/kodezart/prompts/` for tickets that don't need the full setup context.
 
 **Iteration cap and resumption.** The Ralph loop aborts after `KODEZART_MAX_ITERATIONS` (default `5`, max `20`). The cap exists because Claude sessions tend to brick beyond ~5 iterations — context bloat, repeated tool errors, decision drift compound and quality degrades. When the loop hits the cap, kodezart does *not* discard the work:
 


### PR DESCRIPTION
## Summary

Three new bullets in **For AI Agents → Operational notes**:

- **Verify Claude Code on the host.** Operators should run `claude --version` and confirm authentication *before* kicking off workflows; otherwise the first agent invocation fails with a confusing error.
- **Inspect the prompt templates.** Every workflow sends the templates in `src/kodezart/prompts/` to Claude with the ticket interpolated. Operators should read them once so they know what the agent is instructed to do on their repos.
- **Token budget.** This is a heavy pipeline (multiple Claude sessions per workflow); continuous operation will exhaust any plan's usage limits. Mitigations: lower `KODEZART_MAX_ITERATIONS` / `KODEZART_MAX_REVIEWS` or trim sub-agent preambles.

Section is reordered to flow setup → review → config → cost → iteration cap → resumption.

## Test plan

- [x] README renders correctly
- [x] CI runs to confirm no regression