### PR TITLE
refactor(core): promote redact_credentials to public API

### DIFF
--- a/src/kodezart/adapters/claude_agent_executor.py
+++ b/src/kodezart/adapters/claude_agent_executor.py
@@ -12,7 +12,7 @@ from claude_agent_sdk import (
 
 from kodezart.adapters._permission_modes import _validate_permission_mode
 from kodezart.adapters._sdk_mapping import map_message
-from kodezart.core.error_egress import _redact_credentials
+from kodezart.core.error_egress import redact_credentials
 from kodezart.core.logging import BoundLogger, get_logger
 from kodezart.domain.errors import AgentSDKError
 from kodezart.types.domain.agent import AgentEvent
@@ -71,7 +71,7 @@ class ClaudeAgentExecutor:
                 "claude_sdk_process_error",
                 exit_code=exc.exit_code,
                 stderr=(
-                    _redact_credentials(exc.stderr) if exc.stderr is not None else None
+                    redact_credentials(exc.stderr) if exc.stderr is not None else None
                 ),
             )
             raise AgentSDKError(

--- a/src/kodezart/adapters/claude_client_executor.py
+++ b/src/kodezart/adapters/claude_client_executor.py
@@ -15,7 +15,7 @@ from claude_agent_sdk import (
 from kodezart.adapters._permission_modes import _validate_permission_mode
 from kodezart.adapters._sdk_mapping import map_message
 from kodezart.core.constants import STDERR_TAIL_BYTES
-from kodezart.core.error_egress import _redact_credentials
+from kodezart.core.error_egress import redact_credentials
 from kodezart.core.logging import BoundLogger, get_logger
 from kodezart.domain.errors import AgentSDKError
 from kodezart.types.domain.agent import AgentEvent
@@ -78,7 +78,7 @@ class ClaudeClientExecutor:
             # token straddling the STDERR_TAIL_BYTES boundary from
             # surviving partially exposed in stderr_tail.
             stderr_redacted: str | None = (
-                _redact_credentials(exc.stderr) if exc.stderr is not None else None
+                redact_credentials(exc.stderr) if exc.stderr is not None else None
             )
             await self._log.awarning(
                 "claude_sdk_process_error",

--- a/src/kodezart/core/error_egress.py
+++ b/src/kodezart/core/error_egress.py
@@ -31,7 +31,7 @@ _GH_FINEGRAINED_PAT_PATTERN: re.Pattern[str] = re.compile(
 )
 
 
-def _redact_credentials(s: str) -> str:
+def redact_credentials(s: str) -> str:
     """Replace GitHub credential patterns with the redaction sentinel.
 
     Applied at the two ErrorEvent egress fields below and at both
@@ -91,7 +91,7 @@ def build_error_event(exc: Exception) -> ErrorEvent:
         stderr_tail = exc.stderr_tail
 
     return ErrorEvent(
-        error=_redact_credentials(str(exc)),
+        error=redact_credentials(str(exc)),
         error_kind=error_kind,
         cause_class=cause_class,
         stop_reason=stop_reason,
@@ -99,6 +99,6 @@ def build_error_event(exc: Exception) -> ErrorEvent:
         rate_limit_rejected=rate_limit_rejected,
         exit_code=exit_code,
         stderr_tail=(
-            _redact_credentials(stderr_tail) if stderr_tail is not None else None
+            redact_credentials(stderr_tail) if stderr_tail is not None else None
         ),
     )

--- a/tests/core/test_error_egress.py
+++ b/tests/core/test_error_egress.py
@@ -1,7 +1,7 @@
 """Tests for ``core/error_egress.py``.
 
 Covers:
-- the credential-redaction helper (``_redact_credentials``)
+- the credential-redaction helper (``redact_credentials``)
 - ``build_error_event`` applies the helper to both leak-carrying fields
 - ``build_error_event`` carries primitives from ``NoStructuredOutputError``
 - ``build_error_event`` preserves non-secret message text verbatim
@@ -13,8 +13,8 @@ import pytest
 
 from kodezart.core.error_egress import (
     _REDACTION_SENTINEL,
-    _redact_credentials,
     build_error_event,
+    redact_credentials,
 )
 from kodezart.core.errors import NoStructuredOutputError
 from kodezart.domain.errors import AgentSDKError
@@ -32,7 +32,7 @@ _FAKE_URL: Final[str] = (
 
 def test_redact_credentials_redacts_embedded_url_token() -> None:
     """The ``x-access-token:<token>@`` URL form is scrubbed in place."""
-    redacted = _redact_credentials(_FAKE_URL)
+    redacted = redact_credentials(_FAKE_URL)
     assert _FAKE_GHP_BODY not in redacted
     # Scheme + host + path survive — only the secret body is replaced.
     assert "https://x-access-token:" in redacted
@@ -45,7 +45,7 @@ def test_redact_credentials_redacts_bare_classic_tokens(prefix: str) -> None:
     """Each classic GitHub token prefix is scrubbed; surrounding text survives."""
     body = "A" * 40
     src = f"prefix line: {prefix}{body} trailing"
-    redacted = _redact_credentials(src)
+    redacted = redact_credentials(src)
     assert body not in redacted
     assert _REDACTION_SENTINEL in redacted
     assert "prefix line:" in redacted
@@ -55,7 +55,7 @@ def test_redact_credentials_redacts_bare_classic_tokens(prefix: str) -> None:
 def test_redact_credentials_redacts_fine_grained_pat() -> None:
     """``github_pat_`` fine-grained PAT is scrubbed in full."""
     src = f"github_pat_{_FAKE_PAT_BODY}"
-    redacted = _redact_credentials(src)
+    redacted = redact_credentials(src)
     assert _FAKE_PAT_BODY not in redacted
     assert _REDACTION_SENTINEL in redacted
 
@@ -70,13 +70,13 @@ def test_redact_credentials_redacts_fine_grained_pat() -> None:
 )
 def test_redact_credentials_preserves_non_secret_text(src: str) -> None:
     """Non-secret prose, branch names, and short suffixes are untouched."""
-    assert _redact_credentials(src) == src
+    assert redact_credentials(src) == src
 
 
 def test_redact_credentials_is_idempotent() -> None:
     """Re-applying redaction to already-redacted text is a no-op."""
-    once = _redact_credentials(_FAKE_URL)
-    twice = _redact_credentials(once)
+    once = redact_credentials(_FAKE_URL)
+    twice = redact_credentials(once)
     assert once == twice
 
 


### PR DESCRIPTION
## Summary

Stacked cleanup on top of #26. Drops the leading underscore from `core/error_egress._redact_credentials` → `redact_credentials`, because the symbol is consumed **across module boundaries in production code** — a leading-underscore name signals "module-private", so importing it elsewhere contradicts the very convention it exists to express.

This is the deferred follow-up that #26's own description called out: *"no rename of the misleadingly-underscored `_redact_credentials` / `_REDACTION_SENTINEL` (pre-existing flag, separate follow-up)."*

Pure rename — redaction behavior is byte-identical.

## Why it's a smell

`redact_credentials` has two production consumers outside `error_egress.py` that call it to scrub credentials from their `claude_sdk_process_error` log lines:
- `adapters/claude_agent_executor.py`
- `adapters/claude_client_executor.py`

Once a symbol crosses a module boundary in production code it is public API and should be named accordingly. (The cross-boundary import predates #26 — it existed when the symbol lived in `core/soft_failure.py` — so this is not a #26 regression, just the cleanup #26 deferred.)

## Changes

- `core/error_egress.py` — rename `def _redact_credentials` → `def redact_credentials`; update the two internal call sites in `build_error_event`.
- `adapters/claude_agent_executor.py`, `adapters/claude_client_executor.py` — update import + call site.
- `tests/core/test_error_egress.py` — update import (re-sorted: dropping the underscore moves the name after `build_error_event` in ruff's order) + the 6 call sites. Test **function names** (`test_redact_credentials_*`) are intentionally left unchanged — they describe behavior, not the symbol.

## Out of scope

- `_REDACTION_SENTINEL` stays underscored — only test modules (`tests/core/test_error_egress.py`, `tests/adapters/test_claude_executors.py`) read it, and tests reaching into internals is an accepted lesser smell. Happy to promote it too if preferred (+2 test-import edits).
- The three `re.Pattern` constants stay private — no cross-module consumers.

## Verification

- `make format` — fixed point, no diff.
- `make lint` (`ruff check src/ tests/`) — All checks passed.
- `make type-check` (`mypy src/`) — Success, no issues in 75 source files.
- `uv run pytest tests/core/test_error_egress.py tests/adapters/test_claude_executors.py` — 23 passed.
- `git grep _redact_credentials` returns only the descriptive `test_redact_credentials_*` function names; no references to the old private symbol remain.

> Note: the full suite has pre-existing failures in the git-subprocess/integration tests (`test_subprocess_git.py`, `test_workflow_e2e.py`, `test_git_artifact_persister.py`, `test_git_branch_merger.py`) — e.g. `git rev-parse HEAD~` returning a 5-char string in the sandbox. These fail identically on the untouched base branch and are unrelated to this rename.

https://claude.ai/code/session_01XKdZ67uqTSu3EUbV2PPfa5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKdZ67uqTSu3EUbV2PPfa5)_