### PR TITLE
restore(ralph_workflow): re-apply _run_quality_gate helper (#29) + fix_code_node routing (#33)

### DIFF
--- a/src/kodezart/chains/ralph_workflow.py
+++ b/src/kodezart/chains/ralph_workflow.py
@@ -793,19 +793,18 @@ class RalphWorkflowEngine:
             fix_prompt_parts.append(f"\n\n## CI Failures\n{state['ci_summary']}")
         fix_prompt = "".join(fix_prompt_parts)
 
-        async for _event in self._service.stream_workflow(
+        await self._run_quality_gate(
             prompt=fix_prompt,
             repo_path=ctx.repo_path,
             repo_url=ctx.repo_url,
-            base_branch=state["feature_branch"],
-            branch_name=state["feature_branch"],
+            feature_branch=state["feature_branch"],
             ralph_branch=fix_branch,
+            base_branch=state["feature_branch"],
             permission_mode=ctx.permission_mode,
             allowed_tools=ctx.allowed_tools,
-            create_branch=True,
+            acceptance_criteria=state["acceptance_criteria"],
             cache_key=ctx.cache_key,
-        ):
-            pass  # consume stream
+        )
 
         outcome = await self._merger.consolidate(
             repo_path=ctx.repo_path,

--- a/src/kodezart/chains/ralph_workflow.py
+++ b/src/kodezart/chains/ralph_workflow.py
@@ -445,6 +445,45 @@ class RalphWorkflowEngine:
 
         return {"acceptance_criteria": output.criteria}
 
+    async def _run_quality_gate(
+        self,
+        *,
+        prompt: str,
+        repo_path: str | None,
+        repo_url: str | None,
+        feature_branch: str,
+        ralph_branch: str,
+        base_branch: str,
+        permission_mode: str,
+        allowed_tools: list[str],
+        acceptance_criteria: list[str],
+        cache_key: str,
+    ) -> WorkflowIterationEvent:
+        """Delegate to the quality gate for iterative execution."""
+        writer = get_stream_writer()
+        last_iteration_event: WorkflowIterationEvent | None = None
+        async for event in self._quality_gate.run(
+            prompt=prompt,
+            repo_path=repo_path,
+            repo_url=repo_url,
+            feature_branch=feature_branch,
+            ralph_branch=ralph_branch,
+            base_branch=base_branch,
+            permission_mode=permission_mode,
+            allowed_tools=allowed_tools,
+            acceptance_criteria=acceptance_criteria,
+            cache_key=cache_key,
+        ):
+            writer(event)
+            if isinstance(event, WorkflowIterationEvent):
+                last_iteration_event = event
+
+        if last_iteration_event is None:
+            msg = "Ralph loop completed without emitting an iteration event."
+            raise RuntimeError(msg)
+
+        return last_iteration_event
+
     async def _run_ralph_loop_node(
         self,
         state: WorkflowState,
@@ -452,15 +491,13 @@ class RalphWorkflowEngine:
     ) -> dict[str, object]:
         """Delegate to the quality gate for iterative execution."""
         ctx = ExecutionContext.from_configurable(config)
-        writer = get_stream_writer()
 
         ticket = state["ticket"]
         if ticket is None:
             msg = "run_ralph_loop requires a ticket but state['ticket'] is None."
             raise RuntimeError(msg)
 
-        last_iteration_event: WorkflowIterationEvent | None = None
-        async for event in self._quality_gate.run(
+        last_iteration_event = await self._run_quality_gate(
             prompt=format_ticket_as_task(ticket),
             repo_path=ctx.repo_path,
             repo_url=ctx.repo_url,
@@ -471,14 +508,7 @@ class RalphWorkflowEngine:
             allowed_tools=ctx.allowed_tools,
             acceptance_criteria=state["acceptance_criteria"],
             cache_key=ctx.cache_key,
-        ):
-            writer(event)
-            if isinstance(event, WorkflowIterationEvent):
-                last_iteration_event = event
-
-        if last_iteration_event is None:
-            msg = "Ralph loop completed without emitting an iteration event."
-            raise RuntimeError(msg)
+        )
 
         # feature_tip_sha is left None here; _merge_to_feature_node sets it
         # from the merger's outcome.feature_tip_sha (canonical, post-push).

--- a/tests/chains/test_ralph_workflow.py
+++ b/tests/chains/test_ralph_workflow.py
@@ -2777,6 +2777,16 @@ async def test_fix_code_node_invokes_quality_gate_with_feature_base_branch() -> 
     assert len(complete_events) == 1
     assert complete_events[0].accepted is True
 
+    # (d) Downstream SSE consumers receive at least one
+    # ``WorkflowIterationEvent`` per fix round in addition to the
+    # pre-merge round, because ``_run_quality_gate`` calls
+    # ``writer(event)`` on every inner event. A regression that
+    # dropped the writer propagation (or that reverted the fix path
+    # to the event-discarding ``stream_workflow`` consumer) would
+    # otherwise slip through unnoticed.
+    iteration_events = [e for e in events if isinstance(e, WorkflowIterationEvent)]
+    assert len(iteration_events) >= 2
+
 
 async def test_review_uses_review_base_sha_and_review_head_sha_not_branch_refs() -> (
     None

--- a/tests/chains/test_ralph_workflow.py
+++ b/tests/chains/test_ralph_workflow.py
@@ -2746,19 +2746,28 @@ async def test_fix_code_node_invokes_quality_gate_with_feature_base_branch() -> 
     # (a) Exactly two gate invocations: one pre-merge, one fix-path.
     assert len(gate.calls) == 2
 
-    # (b) Fix-path kwargs: base_branch equals feature_branch (so the inner
-    # evaluator diffs against the merged feature tip, not main); acceptance
-    # criteria forwarded; ralph_branch is a fresh kodezart/...-ralph-...
-    # branch off the feature branch.
+    # (b) Differential bases: pre-merge gate uses ctx.base_branch ("main"),
+    # fix-path gate uses state["feature_branch"] (so the inner evaluator
+    # diffs against the merged feature tip, not main). Asserting BOTH
+    # bases proves the two call sites pass different bases — a future
+    # refactor that accidentally forwarded feature_branch to BOTH calls
+    # would otherwise slip through.
+    assert gate.calls[0]["base_branch"] == "main"
     fix_call = gate.calls[1]
     assert fix_call["base_branch"] == fix_call["feature_branch"]
     assert isinstance(fix_call["base_branch"], str)
     assert fix_call["base_branch"].startswith("kodezart/")
+    # Fix-path kwargs: acceptance criteria forwarded; ralph_branch is a
+    # fresh kodezart/...-ralph-... branch off the feature branch; the
+    # fix prompt carries the review-failure body so the routed-through-
+    # gate path preserves the fix-prompt assembly (incl. the
+    # "## Review Failures" header from _fix_code_node).
     assert fix_call["acceptance_criteria"] == ["Tests pass", "No lint errors"]
     assert isinstance(fix_call["ralph_branch"], str)
     assert isinstance(fix_call["feature_branch"], str)
     assert fix_call["ralph_branch"].startswith(fix_call["feature_branch"])
     assert "-ralph-" in fix_call["ralph_branch"]
+    assert "## Review Failures" in str(fix_call["prompt"])
 
     # (c) Terminal accepted reflects the PRE-MERGE verdict. Fix gate
     # returned accepted=False but the post-merge reviewer passed; the

--- a/tests/chains/test_ralph_workflow.py
+++ b/tests/chains/test_ralph_workflow.py
@@ -12,6 +12,7 @@ from kodezart.core.checkpointer import make_checkpointer
 from kodezart.core.protocols import AgentExecutor, TicketGenerator
 from kodezart.services.agent_service import AgentService
 from kodezart.types.domain.agent import (
+    AcceptanceCriteriaOutput,
     AgentEvent,
     AssistantTextEvent,
     ResultEvent,
@@ -2009,10 +2010,11 @@ async def test_workflow_ci_fails_then_passes_after_fix() -> None:
     comment_calls = [c for c in pr_creator.calls if c.get("method") == "comment_on_pr"]
     assert len(comment_calls) == 0
 
-    # P2-AC09: Fix prompt includes CI summary
-    fix_calls = [c for c in executor.calls if c.get("output_format") is None]
-    assert len(fix_calls) >= 1
-    fix_prompt = str(fix_calls[0].get("prompt", ""))
+    # P2-AC09: Fix prompt includes CI summary. The fix path now routes
+    # through _run_quality_gate (gate.calls[1] is the fix invocation;
+    # gate.calls[0] is the pre-merge ralph-loop invocation).
+    assert len(gate.calls) == 2
+    fix_prompt = str(gate.calls[1].get("prompt", ""))
     assert "## CI Failures\nCI failed: lint" in fix_prompt
 
 
@@ -2609,6 +2611,162 @@ async def test_fix_code_node_source_missing_routes_terminally() -> None:
     # Only one review (the first); no re-review after the failed fix consolidation.
     review_events = [e for e in events if isinstance(e, WorkflowReviewEvent)]
     assert len(review_events) == 1
+
+
+class _SequentialQualityGate:
+    """QualityGate that scripts evaluations across calls.
+
+    Mirrors the in-tree ``_SequentialReviewExecutor`` precedent: stateful
+    list of scripted ``AcceptanceCriteriaOutput`` results plus a ``.calls``
+    recorder. One ``WorkflowIterationEvent`` is yielded per ``run`` call,
+    letting tests distinguish the pre-merge gate invocation from the
+    fix-path gate invocation.
+    """
+
+    def __init__(
+        self,
+        evaluations: list[AcceptanceCriteriaOutput],
+        last_commit_sha: str = "a" * 40,
+    ) -> None:
+        self._evaluations = list(evaluations)
+        self._last_commit_sha = last_commit_sha
+        self.calls: list[dict[str, object]] = []
+
+    async def run(
+        self,
+        *,
+        prompt: str,
+        repo_path: str | None,
+        repo_url: str | None,
+        feature_branch: str,
+        ralph_branch: str,
+        base_branch: str,
+        permission_mode: str,
+        allowed_tools: list[str],
+        acceptance_criteria: list[str],
+        cache_key: str,
+    ) -> AsyncGenerator[AgentEvent, None]:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "repo_path": repo_path,
+                "repo_url": repo_url,
+                "feature_branch": feature_branch,
+                "ralph_branch": ralph_branch,
+                "base_branch": base_branch,
+                "permission_mode": permission_mode,
+                "allowed_tools": allowed_tools,
+                "acceptance_criteria": acceptance_criteria,
+                "cache_key": cache_key,
+            }
+        )
+        evaluation = self._evaluations.pop(0)
+        yield WorkflowIterationEvent(
+            iteration=1,
+            branch=ralph_branch,
+            commit_sha=self._last_commit_sha,
+            accepted=all(r.passed for r in evaluation.criteria_results),
+            evaluation=evaluation,
+        )
+
+
+async def test_fix_code_node_invokes_quality_gate_with_feature_base_branch() -> None:
+    """fix_code routes through _run_quality_gate without overwriting state['accepted'].
+
+    Asserts (a) exactly two gate invocations across the workflow,
+    (b) the fix-path call's ``base_branch`` equals ``feature_branch`` and
+    ``acceptance_criteria`` is forwarded, and (c) the terminal
+    ``WorkflowCompleteEvent.accepted`` reflects the PRE-MERGE gate verdict
+    even when the fix gate returns ``accepted=False`` — proving the fix
+    gate does not overwrite the outer ``state['accepted']`` signal.
+    """
+    failing_review: dict[str, object] = {
+        "criteriaResults": [
+            {"criterion": "Tests pass", "passed": False, "reasoning": "Tests fail."},
+        ],
+    }
+    passing_review: dict[str, object] = {
+        "criteriaResults": [
+            {"criterion": "Tests pass", "passed": True, "reasoning": "Tests pass now."},
+        ],
+    }
+    executor = _SequentialReviewExecutor(
+        review_results=[failing_review, passing_review],
+    )
+    # Pre-merge gate returns accepted=True → merge proceeds.
+    # Fix-path gate returns accepted=False → would-be regression case if
+    # _fix_code_node propagated it into state['accepted'].
+    gate = _SequentialQualityGate(
+        evaluations=[make_passing_evaluation(), make_failing_evaluation()],
+    )
+    merger = FakeBranchMerger(
+        consolidation_outcomes=[
+            ConsolidationOutcome(
+                status=ConsolidationStatus.FAST_FORWARDED,
+                feature_tip_sha="a" * 40,
+            ),  # post-loop merge
+            ConsolidationOutcome(
+                status=ConsolidationStatus.FAST_FORWARDED,
+                feature_tip_sha="c" * 40,
+            ),  # fix consolidation
+        ],
+    )
+    service = AgentService(
+        executor=executor,
+        workspace=FakeWorkspaceProvider(),
+        persister=FakeChangePersister(),
+    )
+    engine = RalphWorkflowEngine(
+        service=service,
+        quality_gate=gate,
+        ticket_generator=FakeTicketGenerator(),
+        merger=merger,
+        git_base_url="https://github.com",
+        git_remote="origin",
+        git=FakeGitService(remote_branch_shas={"main": "b" * 40}),
+        cache=FakeRepoCache(),
+        pr_creator=FakePRCreator(),
+        ci_monitor=FakeCIMonitor(passed=True),
+        max_fix_rounds=2,
+        artifact_persister=None,
+    )
+
+    events = [
+        e
+        async for e in engine.run(
+            prompt="fix it",
+            repo_path="/tmp/fake",
+            repo_url="https://github.com/owner/repo",
+            base_branch="main",
+            permission_mode="bypassPermissions",
+            allowed_tools=["Bash"],
+        )
+    ]
+
+    # (a) Exactly two gate invocations: one pre-merge, one fix-path.
+    assert len(gate.calls) == 2
+
+    # (b) Fix-path kwargs: base_branch equals feature_branch (so the inner
+    # evaluator diffs against the merged feature tip, not main); acceptance
+    # criteria forwarded; ralph_branch is a fresh kodezart/...-ralph-...
+    # branch off the feature branch.
+    fix_call = gate.calls[1]
+    assert fix_call["base_branch"] == fix_call["feature_branch"]
+    assert isinstance(fix_call["base_branch"], str)
+    assert fix_call["base_branch"].startswith("kodezart/")
+    assert fix_call["acceptance_criteria"] == ["Tests pass", "No lint errors"]
+    assert isinstance(fix_call["ralph_branch"], str)
+    assert isinstance(fix_call["feature_branch"], str)
+    assert fix_call["ralph_branch"].startswith(fix_call["feature_branch"])
+    assert "-ralph-" in fix_call["ralph_branch"]
+
+    # (c) Terminal accepted reflects the PRE-MERGE verdict. Fix gate
+    # returned accepted=False but the post-merge reviewer passed; the
+    # outer state['accepted'] must remain True so WorkflowCompleteEvent
+    # and the backup-branch cleanup gate stay correct.
+    complete_events = [e for e in events if isinstance(e, WorkflowCompleteEvent)]
+    assert len(complete_events) == 1
+    assert complete_events[0].accepted is True
 
 
 async def test_review_uses_review_base_sha_and_review_head_sha_not_branch_refs() -> (


### PR DESCRIPTION
Closes #32

## What

Restores the `ralph_workflow.py` refactor from PRs #29 and #33, which never reached `main` despite all three stacked PRs (#29 → #33 → #34) being merged:

- **#29** — `_run_quality_gate` helper extracted from `_run_ralph_loop_node`
- **#33** — `_fix_code_node` routed through `_run_quality_gate` (+ tests)

Cherry-picked from the original commits (`b8af7ad`, `80ffe54`, `24412ea`, `fa65d2e`), preserving authorship.

## Why it was missing

The three PRs were squash-merged top-down. Commit `213f6bf` on #34's branch (`revert: restore ralph_workflow.py and test_ralph_workflow.py to base`) had reverted #29's and #33's work to satisfy ticket #34's `[scope]` criterion ("exactly the two prompt files") — but that scope was measured against trunk (#28) instead of #34's stack-parent (#33), so inherited lower-stack code looked like a scope violation. Squash-merge then collapsed each PR to its net diff, cascading the revert all the way to `main`. Result: only #34's prompt changes landed; `_run_quality_gate` was absent from `main`.

#34's prompt changes are already on `main` and are untouched here.

## Verification

- `uv run pytest` → 273 passed, 3 skipped
- `uv run mypy src` → clean
- `uv run ruff check` → clean
- `git diff main -- src/kodezart/prompts/` → empty (prompts untouched)

## Follow-up (not in this PR)

Fix kodezart so a stacked ticket's scope/no-touch check is computed against the PR's parent branch, not trunk — otherwise a future top-of-stack ticket will again revert its inherited work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
